### PR TITLE
Patching CVE-2020-8175

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "homepage": "https://github.com/benwiley4000/gif-frames#readme",
   "dependencies": {
-    "get-pixels-frame-info-update": "^3.3.2",
+    "get-pixels-updated": "1.0.0",
     "multi-integer-range": "^3.0.0",
     "save-pixels-jpeg-js-upgrade": "^2.3.4-jpeg-js-upgrade.0"
   },


### PR DESCRIPTION
I made [a fork](https://github.com/sysollie/get-pixels-updated) of [get-pixels](https://github.com/scijs/get-pixels) so I could patch the [CVE-2020-8175](https://github.com/advisories/GHSA-w7q9-p3jq-fmhm) security issue. Everything under the hood is the same - you can check if you want - only the package.json file and README.md file has been updated.