### PR TITLE
Removed cumulative and calculated it automatically

### DIFF
--- a/gif-frames.d.ts
+++ b/gif-frames.d.ts
@@ -1,6 +1,4 @@
 import {Initializer} from "multi-integer-range";
-import {Canvas} from "canvas";
-import stream from "stream";
 
 declare module "gif-frames" {
 
@@ -15,17 +13,16 @@ declare module "gif-frames" {
         frames: "all" | Initializer;
         outputType?: GifOutputType;
         quality?: number;
-        cumulative?: boolean;
     }
 
     interface GifFrameCanvas {
-        getImage(): Canvas;
+        getImage(): HTMLCanvasElement;
         frameIndex: number;
         frameInfo: GifFrameInfo
     }
 
     interface GifFrameReadableStream {
-        getImage(): stream.Readable;
+        getImage(): NodeJS.ReadableStream;
         frameIndex: number;
         frameInfo: GifFrameInfo
     }

--- a/gif-frames.js
+++ b/gif-frames.js
@@ -52,7 +52,6 @@ function gifFrames (options, callback) {
   }
   var outputType = options.outputType || 'jpg';
   var quality = options.quality;
-  var cumulative = options.cumulative;
 
   var acceptedFrames = frames === 'all' ? 'all' : new MultiRange(frames);
 
@@ -77,7 +76,7 @@ function gifFrames (options, callback) {
       (function (frameIndex) {
         frameData.push({
           getImage: function () {
-            if (cumulative && frameIndex > maxAccumulatedFrame) {
+            if (frameIndex > maxAccumulatedFrame) {
               // for each frame, replace any invisible pixel with
               // the corresponding pixel from the previous frame (beginning
               // with the second frame).
@@ -86,15 +85,19 @@ function gifFrames (options, callback) {
               var lastFrame = pixels.pick(maxAccumulatedFrame);
               for (var f = maxAccumulatedFrame + 1; f <= frameIndex; f++) {
                 var frame = pixels.pick(f);
-                for (var x = 0; x < frame.shape[0]; x++) {
-                  for (var y = 0; y < frame.shape[1]; y++) {
-                    if (frame.get(x, y, 3) === 0) {
-                      // if alpha is fully transparent, use the pixel
-                      // from the last frame
-                      frame.set(x, y, 0, lastFrame.get(x, y, 0));
-                      frame.set(x, y, 1, lastFrame.get(x, y, 1));
-                      frame.set(x, y, 2, lastFrame.get(x, y, 2));
-                      frame.set(x, y, 3, lastFrame.get(x, y, 3));
+                var disposal = framesInfo[f].disposal
+
+                if (disposal !== 3) {
+                  for (var x = 0; x < frame.shape[0]; x++) {
+                    for (var y = 0; y < frame.shape[1]; y++) {
+                      if (frame.get(x, y, 3) === 0) {
+                        // if alpha is fully transparent, use the pixel
+                        // from the last frame
+                        frame.set(x, y, 0, lastFrame.get(x, y, 0));
+                        frame.set(x, y, 1, lastFrame.get(x, y, 1));
+                        frame.set(x, y, 2, lastFrame.get(x, y, 2));
+                        frame.set(x, y, 3, lastFrame.get(x, y, 3));
+                      }
                     }
                   }
                 }

--- a/gif-frames.js
+++ b/gif-frames.js
@@ -87,7 +87,7 @@ function gifFrames (options, callback) {
                 var frame = pixels.pick(f);
                 var disposal = framesInfo[f].disposal
 
-                if (disposal !== 3) {
+                if (disposal === 0 || disposal === 1) {
                   for (var x = 0; x < frame.shape[0]; x++) {
                     for (var y = 0; y < frame.shape[1]; y++) {
                       if (frame.get(x, y, 3) === 0) {


### PR DESCRIPTION
Hi, based on my testing I've found that you can run the cumulative code whenever the frames `disposal` is not equal to `3`. There is an old PR for this same issue https://github.com/benwiley4000/gif-frames/pull/18 but it seems to have been abandoned, and their solution only worked in the browser. This is also related to issue https://github.com/benwiley4000/gif-frames/issues/13.

This PR removes the cumulative option and runs the relevant code only when the frames `disposal !== 3`. 

Finally, I submitted another PR to add typings awhile back but I noticed that it was never uploaded to npm. If you can publish the changes to npm that would be great. I've also fixed the types to use HTMLCanvasElement instead of Node.js Canvas, since that was the intended type. 